### PR TITLE
Optimisations and performance improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "cSpell.words": [
         "Xunit"
     ],
-    "azureFunctions.showTargetFrameworkWarning": false
+    "azureFunctions.showTargetFrameworkWarning": false,
+    "dotnet-test-explorer.testProjectPath": "**/*.sln"
 }

--- a/Src/Azure.Functions.Testing/Azure.Functions.Testing.csproj
+++ b/Src/Azure.Functions.Testing/Azure.Functions.Testing.csproj
@@ -9,7 +9,7 @@
 
 	<PropertyGroup>
 		<PackageId>AzureFunctions.Testing</PackageId>
-		<Version>0.1.4</Version>
+		<Version>0.1.5</Version>
 		<Authors>Lee Sanderson</Authors>
 		<Company>SixSidedDice.com</Company>
 		<Description>Integration testing helper library for Azure Functions in the style of WebApplicationFactory</Description>

--- a/Src/Azure.Functions.Testing/Executable.cs
+++ b/Src/Azure.Functions.Testing/Executable.cs
@@ -51,7 +51,7 @@ internal class Executable : IDisposable
             return exitCodeTask.Result;
         }
 
-        Process!.Kill();
+        Process!.KillProcessTree();
         throw new Exception("Process didn't exit within specified timeout");
     }
 
@@ -64,6 +64,7 @@ internal class Executable : IDisposable
 
         var exitCode = -1;
         var exitCodeTask = Process!.CreateWaitForExitTask();
+        Process.KillProcessTree();
 
         await Task.WhenAny(exitCodeTask, Task.Delay(timeout));
         var processCompleted = exitCodeTask.IsCompleted;

--- a/Src/Azure.Functions.Testing/FunctionApplicationFactory.cs
+++ b/Src/Azure.Functions.Testing/FunctionApplicationFactory.cs
@@ -60,7 +60,7 @@ public sealed class FunctionApplicationFactory : IDisposable
         return InternalCreateClient();
     }
 
-    public void CleanupRunningFunctions()
+    public void KillAllFuncProcesses()
     {
         foreach (var process in Process.GetProcessesByName("func"))
         {

--- a/Src/Azure.Functions.Testing/FunctionApplicationFactory.cs
+++ b/Src/Azure.Functions.Testing/FunctionApplicationFactory.cs
@@ -232,8 +232,7 @@ public sealed class FunctionApplicationFactory : IDisposable
         var (_, exitCode) = await _funcExe.TryGetExitCode(ShutdownDelay);
         if (exitCode > 0)
         {
-            throw new FunctionApplicationFactoryException(
-                $"'func' failed to stopped prematurely with exit code {exitCode}. Check log for more details");
+            Console.WriteLine($"WARNING: 'func' failed to stop with exit code {exitCode}. Check log for more details");
         }
 
         _funcExe.Dispose();

--- a/Src/Azure.Functions.Testing/FunctionApplicationFactory.cs
+++ b/Src/Azure.Functions.Testing/FunctionApplicationFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System.Diagnostics;
+using System.Net.Sockets;
 
 namespace Azure.Functions.Testing;
 
@@ -57,6 +58,21 @@ public sealed class FunctionApplicationFactory : IDisposable
     {
         await Start();
         return InternalCreateClient();
+    }
+
+    public void CleanupRunningFunctions()
+    {
+        foreach (var process in Process.GetProcessesByName("func"))
+        {
+            try
+            {
+                process.KillProcessTree();
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
     }
 
     private HttpClient InternalCreateClient()

--- a/Src/Azure.Functions.Testing/NuGet/PackageReadme.md
+++ b/Src/Azure.Functions.Testing/NuGet/PackageReadme.md
@@ -100,6 +100,7 @@ task can be used to install dependencies.
 
 | Version | Major Changes |  
 | --- | --- | 
+| 0.1.5 | Optimizations and performance fixes  |  
 | 0.1.4 | Fixed bug when using health check and function is not receiving requests  |  
 | 0.1.3 | Added support for health check on startup  |  
 | 0.1.2 | Added support for running in CI pipelines as well as locally |  

--- a/Src/Azure.Functions.Testing/OsDetector.cs
+++ b/Src/Azure.Functions.Testing/OsDetector.cs
@@ -1,0 +1,19 @@
+﻿namespace Azure.Functions.Testing;
+
+public static class OsDetector
+{
+    public static bool IsOnWindows()
+    {
+        switch (Environment.OSVersion.Platform)
+        {
+            case PlatformID.Win32NT:
+            case PlatformID.Win32S:
+            case PlatformID.Win32Windows:
+            case PlatformID.WinCE:
+            case PlatformID.Xbox:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/Src/Azure.Functions.Testing/ProcessExtensions.cs
+++ b/Src/Azure.Functions.Testing/ProcessExtensions.cs
@@ -48,7 +48,7 @@ internal static class ProcessExtensions
             return process.GetParentProcessLinux();
         }
 
-        if (!process.TryGetProcessHandle(out IntPtr processHandle))
+        if (!process.TryGetProcessHandle(out var processHandle))
         {
             return null;
         }
@@ -83,14 +83,16 @@ internal static class ProcessExtensions
         try
         {
             var procPath = "/proc/" + process.Id + "/stat";
-
-            var lines = File.ReadLines(procPath);
-            var match = Regex.Match(lines.First(), @"\d+\s+\((.*?)\)\s+\w+\s+(\d+)\s");
-
-            if (match.Success)
+            if (File.Exists(procPath))
             {
-                var ppid = int.Parse(match.Groups[2].Value);
-                return ppid < 1 ? null : Process.GetProcessById(ppid);
+                var lines = File.ReadLines(procPath);
+                var match = Regex.Match(lines.First(), @"\d+\s+\((.*?)\)\s+\w+\s+(\d+)\s");
+
+                if (match.Success)
+                {
+                    var ppid = int.Parse(match.Groups[2].Value);
+                    return ppid < 1 ? null : Process.GetProcessById(ppid);
+                }
             }
         }
         catch

--- a/Tests/Azure.Functions.Testing.Tests/Azure.Functions.Testing.Tests.csproj
+++ b/Tests/Azure.Functions.Testing.Tests/Azure.Functions.Testing.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Dotnet/Dotnet.Function.Demo.Tests/Dotnet.Function.Demo.Tests.csproj
+++ b/Tests/Dotnet/Dotnet.Function.Demo.Tests/Dotnet.Function.Demo.Tests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/AnotherHelloFeatureThatSharesFixture.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/AnotherHelloFeatureThatSharesFixture.cs
@@ -17,11 +17,13 @@ public class AnotherHelloFeatureThatSharesFixture : TestBase
     [Fact]
     public async Task HelloIsOkay()
     {
+        ConsoleLogger.WriteLine($"Starting test {nameof(AnotherHelloFeatureThatSharesFixture)}.{nameof(HelloIsOkay)}");
         using var client = await ClientFixture.CreateClient();
 
         var response = await client.GetAsync(GetHelloUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        ConsoleLogger.WriteLine($"Completed test {nameof(AnotherHelloFeatureThatSharesFixture)}.{nameof(HelloIsOkay)}");
     }
 
 }

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/AnotherHelloFeatureThatSharesFixture.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/AnotherHelloFeatureThatSharesFixture.cs
@@ -2,27 +2,22 @@ using System.Net;
 using Dotnet.Function.Demo.XunitCollectionFixtureTests;
 using FluentAssertions;
 using Xunit.Abstractions;
-using Xunit.Shared;
 
 namespace Dotnet.Function.Demo.XUnitCollectionFixtureTests;
 
-[Collection(nameof(HttpClientFixture))]
-public class AnotherHelloFeatureThatSharesFixture
+public class AnotherHelloFeatureThatSharesFixture : TestBase
 {
     private const string GetHelloUri = "/api/Hello";
 
-    private readonly HttpClientFixture _clientFixture;
-
-    public AnotherHelloFeatureThatSharesFixture(ITestOutputHelper output, HttpClientFixture clientFixture)
+    public AnotherHelloFeatureThatSharesFixture(ITestOutputHelper output, HttpClientFixture clientFixture):
+        base(output, clientFixture)
     {
-        _clientFixture = clientFixture;
-        Console.SetOut(new TestOutputConsoleAdapter(output));
     }
 
     [Fact]
     public async Task HelloIsOkay()
     {
-        using var client = await _clientFixture.CreateClient();
+        using var client = await ClientFixture.CreateClient();
 
         var response = await client.GetAsync(GetHelloUri);
 

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/Dotnet.Function.Demo.XunitCollectionFixtureTests.csproj
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/Dotnet.Function.Demo.XunitCollectionFixtureTests.csproj
@@ -26,5 +26,8 @@
     <ProjectReference Include="..\..\..\src\Azure.Functions.Testing\Azure.Functions.Testing.csproj" />
     <ProjectReference Include="..\..\Xunit.Shared\Xunit.Shared.csproj" />
   </ItemGroup>
-
+	
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/Dotnet.Function.Demo.XunitCollectionFixtureTests.csproj
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/Dotnet.Function.Demo.XunitCollectionFixtureTests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HelloFeatureThatSharesFixture.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HelloFeatureThatSharesFixture.cs
@@ -17,10 +17,12 @@ public class HelloFeatureThatSharesFixture : TestBase
     [Fact]
     public async Task HelloIsOkay()
     {
+        ConsoleLogger.WriteLine($"Starting test {nameof(HelloFeatureThatSharesFixture)}.{nameof(HelloIsOkay)}");
         using var client = await ClientFixture.CreateClient();
 
         var response = await client.GetAsync(GetHelloUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        ConsoleLogger.WriteLine($"Completed test {nameof(HelloFeatureThatSharesFixture)}.{nameof(HelloIsOkay)}");
     }
 }

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HelloFeatureThatSharesFixture.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HelloFeatureThatSharesFixture.cs
@@ -1,33 +1,26 @@
 using Dotnet.Function.Demo.XunitCollectionFixtureTests;
 using System.Net;
 using Xunit.Abstractions;
-using Xunit.Shared;
 using FluentAssertions;
 
 namespace Dotnet.Function.Demo.XUnitCollectionFixtureTests;
 
-
-[Collection(nameof(HttpClientFixture))]
-public class HelloFeatureThatSharesFixture
+public class HelloFeatureThatSharesFixture : TestBase
 {
     private const string GetHelloUri = "/api/Hello";
 
-    private readonly HttpClientFixture _clientFixture;
-
-    public HelloFeatureThatSharesFixture(ITestOutputHelper output, HttpClientFixture clientFixture)
+    public HelloFeatureThatSharesFixture(ITestOutputHelper output, HttpClientFixture clientFixture):
+        base(output, clientFixture)
     {
-        _clientFixture = clientFixture;
-        Console.SetOut(new TestOutputConsoleAdapter(output));
     }
 
     [Fact]
     public async Task HelloIsOkay()
     {
-        using var client = await _clientFixture.CreateClient();
+        using var client = await ClientFixture.CreateClient();
 
         var response = await client.GetAsync(GetHelloUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
-
 }

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HttpClientFixture.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HttpClientFixture.cs
@@ -1,4 +1,6 @@
 ﻿using Azure.Functions.Testing;
+using Xunit.Abstractions;
+using Xunit.Shared;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 
@@ -8,19 +10,22 @@ namespace Dotnet.Function.Demo.XunitCollectionFixtureTests;
 public class HttpClientFixture : IDisposable, IAsyncLifetime
 {
     private readonly FunctionApplicationFactory _factory;
+    private readonly MessageSinkConsoleAdapter _messageSinkConsoleAdapter;
 
-    public HttpClientFixture()
+    public HttpClientFixture(IMessageSink diagnosticMessageSink)
     {
         // Create factory for local testing. Could use environment variables to switch between local
         // testing and testing a deployed function (just need to create a HTTP client with a BaseAddress)
         _factory = new FunctionApplicationFactory(
             FunctionLocator.FromProject("Dotnet.Function.Demo"), "--verbose", "--debug", "--csharp");
+        _messageSinkConsoleAdapter = new MessageSinkConsoleAdapter(diagnosticMessageSink);
     }
 
     public async Task<HttpClient> CreateClient() => await _factory.CreateClient().ConfigureAwait(false);
 
     public void Dispose()
     {
+        _messageSinkConsoleAdapter.Dispose();
         _factory.Dispose();
     }
 

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HttpClientFixture.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/HttpClientFixture.cs
@@ -28,7 +28,7 @@ public class HttpClientFixture : IDisposable, IAsyncLifetime
     {
         // Set startup timeout. Adjust depending on build time of Function project;
         _factory.StartupDelay = TimeSpan.FromSeconds(20);
-
+        _factory.KillAllFuncProcesses();
         return _factory.Start();
     }
 

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/TestBase.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/TestBase.cs
@@ -1,0 +1,22 @@
+﻿using Xunit.Abstractions;
+using Xunit.Shared;
+
+namespace Dotnet.Function.Demo.XunitCollectionFixtureTests;
+
+[Collection(nameof(HttpClientFixture))]
+public abstract class TestBase : IDisposable
+{
+    private readonly TestOutputConsoleAdapter _outputConsoleAdapter;
+    protected readonly HttpClientFixture ClientFixture;
+
+    protected TestBase(ITestOutputHelper output, HttpClientFixture clientFixture)
+    {
+        ClientFixture = clientFixture;
+        _outputConsoleAdapter = new TestOutputConsoleAdapter(output);
+    }
+
+    public void Dispose()
+    {
+        _outputConsoleAdapter.Dispose();
+    }
+}

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/TestBase.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/TestBase.cs
@@ -6,17 +6,17 @@ namespace Dotnet.Function.Demo.XunitCollectionFixtureTests;
 [Collection(nameof(HttpClientFixture))]
 public abstract class TestBase : IDisposable
 {
-    private readonly TestOutputConsoleAdapter _outputConsoleAdapter;
+    protected readonly TestOutputConsoleAdapter ConsoleLogger;
     protected readonly HttpClientFixture ClientFixture;
 
     protected TestBase(ITestOutputHelper output, HttpClientFixture clientFixture)
     {
         ClientFixture = clientFixture;
-        _outputConsoleAdapter = new TestOutputConsoleAdapter(output);
+        ConsoleLogger = new TestOutputConsoleAdapter(output);
     }
 
     public void Dispose()
     {
-        _outputConsoleAdapter.Dispose();
+        ConsoleLogger.Dispose();
     }
 }

--- a/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/xunit.runner.json
+++ b/Tests/Dotnet/Dotnet.Function.Demo.XunitCollectionFixtureTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true
+}

--- a/Tests/Dotnet/Dotnet.Function.Demo/Dotnet.Function.Demo.csproj
+++ b/Tests/Dotnet/Dotnet.Function.Demo/Dotnet.Function.Demo.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Tests/Dotnet/Dotnet.Function.Demo/Startup.cs
+++ b/Tests/Dotnet/Dotnet.Function.Demo/Startup.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
-using System;
 
 [assembly: FunctionsStartup(typeof(Dotnet.Function.Demo.Startup))]
 namespace Dotnet.Function.Demo;

--- a/Tests/Xunit.Shared/TestOutputConsoleAdapter.cs
+++ b/Tests/Xunit.Shared/TestOutputConsoleAdapter.cs
@@ -7,22 +7,28 @@ namespace Xunit.Shared;
 
 public class TestOutputConsoleAdapter : TextWriter
 {
-    private readonly ITestOutputHelper _output;
+    private ITestOutputHelper? _output;
 
     public TestOutputConsoleAdapter(ITestOutputHelper output)
     {
         _output = output;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        _output = null;
+        base.Dispose(disposing);
+    }
+
     public override Encoding Encoding => Encoding.UTF8;
 
     public override void WriteLine(string? message)
     {
-        _output.WriteLine(message ?? string.Empty);
+        _output?.WriteLine(message ?? string.Empty);
     }
     public override void WriteLine(string format, params object?[] args)
     {
-        _output.WriteLine(format, args);
+        _output?.WriteLine(format, args);
     }
 
     public override void Write(char value)

--- a/Tests/Xunit.Shared/Xunit.Shared.csproj
+++ b/Tests/Xunit.Shared/Xunit.Shared.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Kill function (and function process tree) when tidying up
- Optionally kill function processes before start of test
- Update example using xunit to be more robust