### PR TITLE
Handle InvalidOperationException from Process.Handle to reduce noise …

### DIFF
--- a/Src/Azure.Functions.Testing/Azure.Functions.Testing.csproj
+++ b/Src/Azure.Functions.Testing/Azure.Functions.Testing.csproj
@@ -9,7 +9,7 @@
 
 	<PropertyGroup>
 		<PackageId>AzureFunctions.Testing</PackageId>
-		<Version>0.1.5</Version>
+		<Version>0.1.6</Version>
 		<Authors>Lee Sanderson</Authors>
 		<Company>SixSidedDice.com</Company>
 		<Description>Integration testing helper library for Azure Functions in the style of WebApplicationFactory</Description>

--- a/Src/Azure.Functions.Testing/NuGet/PackageReadme.md
+++ b/Src/Azure.Functions.Testing/NuGet/PackageReadme.md
@@ -98,11 +98,12 @@ task can be used to install dependencies.
 
 ## Version History
 
-| Version | Major Changes |  
-| --- | --- | 
-| 0.1.5 | Optimizations and performance fixes  |  
-| 0.1.4 | Fixed bug when using health check and function is not receiving requests  |  
-| 0.1.3 | Added support for health check on startup  |  
-| 0.1.2 | Added support for running in CI pipelines as well as locally |  
-| 0.1.1 | Expose Start and Stop methods to allow initialization |  
-| 0.1.0 | Initial version |  
+| Version | Major Changes                                                                          |  
+|---------|----------------------------------------------------------------------------------------| 
+| 0.1.6   | Fixed intermittent bug where Stop method would error as the process had already exited |  
+| 0.1.5   | Optimizations and performance fixes                                                    |  
+| 0.1.4   | Fixed bug when using health check and function is not receiving requests               |  
+| 0.1.3   | Added support for health check on startup                                              |  
+| 0.1.2   | Added support for running in CI pipelines as well as locally                           |  
+| 0.1.1   | Expose Start and Stop methods to allow initialization                                  |  
+| 0.1.0   | Initial version                                                                        |  

--- a/Src/Azure.Functions.Testing/ProcessExtensions.cs
+++ b/Src/Azure.Functions.Testing/ProcessExtensions.cs
@@ -147,17 +147,23 @@ internal static class ProcessExtensions
     {
         try
         {
-            // This may fail due to access denied.
-            // Handle the exception to reduce noises in trace errors.
             processHandle = process.Handle;
         }
         catch (Win32Exception ex)
         {
+            // process.Handle may fail due to access denied.
+            // Handle the exception to reduce noises in trace errors.
             if (ex.NativeErrorCode != 5)
             {
                 throw;
             }
 
+            processHandle = IntPtr.Zero;
+        }
+        catch (InvalidOperationException)
+        {
+            // process.Handle may fail if the process has already exited.
+            // Handle the exception to reduce noises in trace errors.
             processHandle = IntPtr.Zero;
         }
 


### PR DESCRIPTION
…when the process has already exited.

Hey Lee,

I saw the error below intermittently at our previous project and, unfortunately, it seems more prevalent when testing an out-of-process hosted Function. Some sort of race condition I suspect. Anyway, the fix seems straight-forward. Thoughts?

Thanks,

Mike.

`System.InvalidOperationException
Cannot process request because the process (31576) has exited.
   at System.Diagnostics.ProcessManager.OpenProcess(Int32 processId, Int32 access, Boolean throwIfExited)
   at System.Diagnostics.Process.GetProcessHandle(Int32 access, Boolean throwIfExited)
   at Azure.Functions.Testing.ProcessExtensions.TryGetProcessHandle(Process process, IntPtr& processHandle)
   at Azure.Functions.Testing.ProcessExtensions.GetParentProcess(Process process)
   at Azure.Functions.Testing.ProcessExtensions.GetProcessTree()
   at Azure.Functions.Testing.ProcessExtensions.GetChildren(Process process, Boolean recursive)
   at Azure.Functions.Testing.ProcessExtensions.KillProcessTree(Process process)
   at Azure.Functions.Testing.Executable.TryGetExitCode(TimeSpan timeout)
   at Azure.Functions.Testing.FunctionApplicationFactory.Stop()
   at Jigsaw.Api.IntegrationTests.HttpClientFixture.DisposeAsync() in <redacted>\HttpClientFixture.cs:line 88
   at Xunit.Sdk.ExceptionAggregator.RunAsync(Func'1 code) in /_/src/xunit.core/Sdk/ExceptionAggregator.cs:line 90`